### PR TITLE
Make the addon work also with Pycharm

### DIFF
--- a/addon/appModules/idea64.py
+++ b/addon/appModules/idea64.py
@@ -177,7 +177,7 @@ class AppModule(appModuleHandler.AppModule):
 
 	def getStatusBar(self, refresh: bool = False):
 		obj = api.getForegroundObject()
-		if obj is None or not obj.appModule.appName == "idea64":
+		if obj is None or not obj.appModule.appName in ("idea64", "pycharm64"):
 			# Ignore cases nvda is lost
 			return
 		if self.status and not refresh:

--- a/addon/appModules/pycharm64.py
+++ b/addon/appModules/pycharm64.py
@@ -1,0 +1,1 @@
+from .idea64 import AppModule


### PR DESCRIPTION
This pull request changes the status bar detecting logic to include the Pycharm executable, so the errors can also be spoken using it. It also adds a pycharm64 module pointing to the same class as IntelliJ so it can use the same functionality provided by the addon for IntelliJ.